### PR TITLE
Unexpected errors: Markdown linting rules

### DIFF
--- a/src/controllers/lint-config-controller.ts
+++ b/src/controllers/lint-config-controller.ts
@@ -137,24 +137,19 @@ export function checkMarkdownlintConfigSettings() {
 	const configProperty = 'markdownlint.config';
 	const configPropertyData: any = workspace.getConfiguration().inspect(configProperty);
 	const customLintConfig = DEFAULT_MARKDOWNLINT_CONFIG;
-	// If the markdownlint.config property exists in package.json, check for existing user settings
+	// If the markdownlint.config property exists in package.json, do not overwrite it in the user settings.
 	if (configPropertyData) {
 		if (configPropertyData.globalValue) {
-			const existingUserSettings = configPropertyData.globalValue;
-			Object.assign(customLintConfig, existingUserSettings);
-			workspace
-				.getConfiguration()
-				.update(configProperty, customLintConfig, ConfigurationTarget.Global);
-				output.appendLine(
-					`[${msTimeValue}] - Adobe default markdownlint config settings merged with user settings.`
-				);
+			output.appendLine(
+				`[${msTimeValue}] - user has existing markdownlint.config settings.  No changes made.`
+			);
 		} else {
 			workspace
 				.getConfiguration()
 				.update(configProperty, customLintConfig, ConfigurationTarget.Global);
-				output.appendLine(
-					`[${msTimeValue}] - Adobe default markdownlint config settings added to user settings.`
-				);
+			output.appendLine(
+				`[${msTimeValue}] - Adobe default markdownlint config settings added to user settings.`
+			);
 		}
 	}
 


### PR DESCRIPTION
Fixes #41
Fixed markdownlint configuration settings.  User settings now  take precedence over defult settings.